### PR TITLE
Fix windows build

### DIFF
--- a/src/spmod.hpp
+++ b/src/spmod.hpp
@@ -77,10 +77,10 @@
 
 #if __has_include(<filesystem>)
     #include <filesystem>
-    // As of GCC 8.1 and Clang 7 filesystem is no longer part of experimental
-    #if (defined SP_GCC && __GNUC__ >= 8) || (defined SP_CLANG && __clang_major__ >= 7)
+    // As of GCC 8.1, Clang 7 and MSVC 2019 filesystem is no longer part of experimental
+    #if (defined SP_GCC && __GNUC__ >= 8) || (defined SP_CLANG && __clang_major__ >= 7) || (defined SP_MSVC && _MSC_VER >= 1920)
         namespace fs = std::filesystem;
-    #else // Some compilers still have filesystem within experimental namespace like MSVC
+    #else // Some compilers still have filesystem within experimental namespace like MSVC 2017
         namespace fs = std::experimental::filesystem;
     #endif
 #elif __has_include(<experimental/filesystem>)


### PR DESCRIPTION
Fix windows build

## Description
Add extra condition to check if msvc is 2019 or greater.

## Motivation and Context
It fixes windows compilation since filesystem library has been moved out of `experimental` since MSVC 2019.

## How has this been tested?
AppVeyor will do its job

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
