### PR TITLE
Refresh build system

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
   - mkdir dlls
   - cd ..
   - ps: Start-FileDownload 'https://github.com/mesonbuild/meson/releases/download/0.50.1/meson-0.50.1-64.msi'
-  - start /wait msiexec.exe /i meson-0.50.1-64.msi /quiet /qn /norestart /log install.log
+  - start /wait msiexec.exe /i meson-0.50.1-64.msi /quiet /qn /norestart
   - cd SPMod
   # Install ambuild
 #  - git clone --depth=1 https://github.com/alliedmodders/ambuild.git
@@ -37,14 +37,7 @@ install:
 #  - move compiler\spcomp\spcomp.exe ..\..\..\scripts
 #  - cd ..\..\..
 build_script:
-  - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars32.bat"
-  - mkdir build
-  - cd build
-  - meson .. . --buildtype plain -D windebug=false -D linktype=%LINK_TYPE%
-  - meson configure
-  - ninja -v
-  - cd ..
-  - move build\src\spmod_mm.dll dlls
+  - ps: appveyor\build.ps1
   - ps: appveyor\package.ps1
 deploy:
   - provider: GitHub

--- a/appveyor/build.ps1
+++ b/appveyor/build.ps1
@@ -1,0 +1,10 @@
+$VS_CRT_TYPE = If ($env:LINK_TYPE -eq "dynamic") {"md"} Else {"mt"}
+
+Start-Process "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars32.bat"
+mkdir build
+cd build
+meson .. . --buildtype release --werror --warnlevel 3 --optimization 3 -D b_vscrt=$VS_CRT_TYPE -D linktype=$env:LINK_TYPE -D b_ndebug=true -D cpp_std=c++17 -D c_std=c11
+meson configure
+ninja -v
+cd ..
+move build\src\spmod_mm.dll dlls

--- a/meson.build
+++ b/meson.build
@@ -58,10 +58,12 @@ if build_machine.system() == 'linux'
             ]
         endif
 
-        if (cppCompiler.version() >= '7.0.0')
-            gLinkArgs += '-lc++fs'
-        else
-            gLinkArgs += '-lc++experimental'
+        if (cppCompiler.version() < '9.0.0')
+            if (cppCompiler.version() >= '7.0.0')
+                gLinkArgs += '-lc++fs'
+            else
+                gLinkArgs += '-lc++experimental'
+            endif
         endif
 
     elif cppCompiler.get_id() == 'gcc'
@@ -77,26 +79,14 @@ if build_machine.system() == 'linux'
                 '-static-libstdc++'
             ]
         endif
-        gLinkArgs += '-lstdc++fs'
+
+        if cppCompiler.version() < '9.0.0'
+            gLinkArgs += '-lstdc++fs'
+        endif
 
     else
         error('Either Clang or GCC is supported.')
     endif
-
-    # If standard is not set, set the minimum one
-    if get_option('c_std') == 'none'
-        gCArgs += '-std=c11'
-    endif
-    if get_option('cpp_std') == 'none'
-        gCppArgs += '-std=c++17'
-    endif
-
-    #-Wall and -Wextra are set by warning_level option
-    gCppArgs += [
-        '-Wno-unknown-pragmas',
-        '-fvisibility=hidden',
-        '-Werror'
-    ]
 elif build_machine.system() == 'windows'
     if cppCompiler.get_id() != 'msvc'
         error('Only MSVC is supported.')
@@ -104,40 +94,9 @@ elif build_machine.system() == 'windows'
 
     gLinkArgs += '/MACHINE:X86'
 
-    # At the time of writing MSVC support is not mature enough
-    if get_option('buildtype') != 'plain'
-        warning('Configure build dir with "meson .. . --buildtype plain"')
-    endif
-
     gCppArgs += [
-        '/W4',  # Warning level 4
-        '/TP',  # Treat files as c++ sources
-        '/WX'   # Treat warnings as errors
+        '/TP'  # Treat files as c++ sources
     ]
-
-    # MSVC support is limited, we need to set compile options here for the time being
-    gCppArgs += '/std:c++17'
-    if get_option('windebug') == true
-        gCppArgs += '/RTC1'  # runtime checks
-
-        if get_option('linktype') == 'dynamic'
-            gCppArgs += '/MDd'
-        endif
-    else
-        gCppArgs += [
-            '/O2',    # optimization fast code
-            '/GL'     # whole program optimization
-        ]
-
-        if get_option('linktype') == 'dynamic'
-            gCppArgs += '/MD'
-        endif
-
-        gLinkArgs += [
-            '/LTCG',   # linker optimization
-            '/DEBUG:NONE' # Meson adds /DEBUG by default, we need to override it
-        ]
-    endif
 endif
 
 # Generate SPConfig.hpp
@@ -179,7 +138,23 @@ includeDirs = include_directories(publicIncludesDir,
                                   rehldsIncludesDir,
                                   metamodIncludesDir,
                                   llvmIncludesDir,
-                                  '.') #build directory
+                                  is_system: true)
+
+# clang workaround, remove when no longer needed
+if cppCompiler.get_id() == 'clang'
+    includeDirs = include_directories(publicIncludesDir,
+                                      rehldsIncludesDir,
+                                      metamodIncludesDir,
+                                      llvmIncludesDir,
+                                      '.',
+                                      is_system: true)
+else
+    includeDirs = include_directories(publicIncludesDir,
+                                      rehldsIncludesDir,
+                                      metamodIncludesDir,
+                                      llvmIncludesDir,
+                                      is_system: true)
+endif
 
 subdir('src')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,2 @@
-option('windebug', type : 'boolean', value : true, description : 'Enable debug build (Windows only)')
 option('linktype', type : 'combo', choices : [ 'static', 'dynamic' ], value : 'static', description : 'Linking type')
 option('extensions', type : 'array', choices : ['all', 'sourcepawn', 'example'], value : ['example'], description : 'Extensions to be built')

--- a/src/meson.build
+++ b/src/meson.build
@@ -31,4 +31,4 @@ sourceFiles = files('h_export.cpp',
                     'NativeProxy.cpp',
                     'EngineFuncs.cpp')
 
-shared_library('spmod_mm', sourceFiles, include_directories : includeDirs)
+shared_library('spmod_mm', sourceFiles, include_directories : includeDirs, gnu_symbol_visibility : 'hidden')

--- a/subprojects/example/meson.build
+++ b/subprojects/example/meson.build
@@ -45,6 +45,6 @@ includeDirs = include_directories(publicIncludesDir,
                                   rehldsIncludesDir,
                                   metamodIncludesDir,
                                   llvmIncludesDir,
-                                  '.') #build directory
+                                  is_system: true)
 
-shared_library('example', sourceFiles, include_directories : includeDirs)
+shared_library('example', sourceFiles, include_directories : includeDirs, gnu_symbol_visibility : 'hidden')

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 mkdir -p build
 cd build
-python /usr/bin/meson .. . --buildtype release --warnlevel 3 -D linktype=$LINK_TYPE -D b_lto=true
+python /usr/bin/meson .. . --buildtype release --werror --optimization 3 --warnlevel 3 -D linktype=$LINK_TYPE -D b_lto=true -D cpp_std=c++17 -D c_std=c11
 python /usr/bin/meson configure
 ninja -v


### PR DESCRIPTION
Custom windows debug has been removed and it's now recommended to use built-in meson options. 

## Description
Meson build files has been updated.

- Custom windows debug build option removed
- When using (clang/gcc) 9 and above, linking with libc++fs/libstdc++fs is removed, since filesystem has been merged with standard library
- Build script is now written for AppVeyor
- Third party includes are treated as system headers now, this way there will be no more errors related to their code and no pragams will be needed anymore (except windows, AFAIK this is already supported in visual studio but not in meson yet)

## Motivation and Context
Since meson getting more features, there's no reason to keep things which were written while ago.

## How has this been tested?
Travis & AppVeyor will do their jobs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
