### PR TITLE
Update engine api

### DIFF
--- a/include/public/ICmdSystem.hpp
+++ b/include/public/ICmdSystem.hpp
@@ -26,7 +26,7 @@ namespace SPMod
     class ICommand
     {
     public:
-        using Callback = IForward::ReturnValue (*)(IPlayer *const player, const ICommand *const cmd);
+        using Callback = IForward::ReturnValue (*)(IPlayer *const player, const ICommand *const cmd, void *data);
 
         enum class Type : std::uint8_t
         {
@@ -47,13 +47,6 @@ namespace SPMod
          * @return Command's info.
          */
         virtual const char *getInfo() const = 0;
-
-        /**
-         * @brief Returns command's data.
-         *
-         * @return Command's data.
-         */
-        virtual void *getData() const = 0;
 
         /**
          * @brief Checks if player can execute the command.
@@ -121,7 +114,7 @@ namespace SPMod
                                           const char *cmd,
                                           const char *info,
                                           std::uint32_t flags,
-                                          ICommand::Callback *cb,
+                                          ICommand::Callback cb,
                                           void *data) = 0;
 
     protected:

--- a/include/public/IEdict.hpp
+++ b/include/public/IEdict.hpp
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (C) 2019 SPMod Development Team
+ *
+ *  This file is part of SPMod.
+ *
+ *  SPMod is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  SPMod is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with SPMod.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace SPMod
+{
+    class IEdict : public ISPModInterface
+    {
+    public:
+        static constexpr std::uint16_t MAJOR_VERSION = 0;
+        static constexpr std::uint16_t MINOR_VERSION = 0;
+
+        static constexpr std::uint32_t VERSION = (MAJOR_VERSION << 16 | MINOR_VERSION);
+        /**
+         * @brief Gets interface's name.
+         *
+         * @return        Interface's name.
+         */
+        const char *getName() const override
+        {
+            return "IEdict";
+        }
+
+        /**
+         * @brief Gets interface's version.
+         *
+         * @note The first 16 most significant bits represent major version, the rest represent minor version.
+         *
+         * @return        Interface's version.
+         */
+        std::uint32_t getVersion() const override
+        {
+            return VERSION;
+        }
+
+        /**
+         * @brief Returns edict's index.
+         *
+         * @return Edict's index.
+         */
+        virtual int getIndex() const = 0;
+
+        virtual const char *getClassName() const = 0;
+        virtual void getOrigin(float *origin) const = 0;
+        virtual void getVelocity(float *velocity) const = 0;
+        virtual void setVelocity(const float *velocity) = 0;
+        virtual float getHealth() const = 0;
+        virtual void setHealth(float health) = 0;
+        virtual void *getPrivateData() const = 0;
+
+    protected:
+        virtual ~IEdict() = default;
+    };
+} // namespace SPMod

--- a/include/public/IEngineFuncs.hpp
+++ b/include/public/IEngineFuncs.hpp
@@ -1,243 +1,351 @@
 /*
-*  Copyright (C) 2018 SPMod Development Team
-*
-*  This file is part of SPMod.
-*
-*  SPMod is free software: you can redistribute it and/or modify
-*  it under the terms of the GNU General Public License as published by
-*  the Free Software Foundation, either version 3 of the License, or
-*  (at your option) any later version.
-*  This program is distributed in the hope that it will be useful,
-*  but WITHOUT ANY WARRANTY; without even the implied warranty of
-*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*  GNU General Public License for more details.
-*  You should have received a copy of the GNU General Public License
-*  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-*/
+ *  Copyright (C) 2019 SPMod Development Team
+ *
+ *  This file is part of SPMod.
+ *
+ *  SPMod is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  SPMod is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with SPMod.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 #pragma once
 
 namespace SPMod
 {
-    class IEngineFuncs
+    class IEngineFuncs : public ISPModInterface
     {
     public:
+        static constexpr std::uint16_t MAJOR_VERSION = 0;
+        static constexpr std::uint16_t MINOR_VERSION = 0;
+
+        static constexpr std::uint32_t VERSION = (MAJOR_VERSION << 16 | MINOR_VERSION);
+        /**
+         * @brief Gets interface's name.
+         *
+         * @return        Interface's name.
+         */
+        const char *getName() const override
+        {
+            return "IEngineFuncs";
+        }
+
+        /**
+         * @brief Gets interface's version.
+         *
+         * @note The first 16 most significant bits represent major version, the rest represent minor version.
+         *
+         * @return        Interface's version.
+         */
+        std::uint32_t getVersion() const override
+        {
+            return VERSION;
+        }
+
         /**
          * @brief Returns current command's argument.
-         * 
+         *
          * @param arg          Argument to get.
-         * 
+         *
          * @return Command's argument.
          */
         virtual const char *getArg(int arg) const = 0;
 
         /**
          * @brief Returns current command's arguments.
-         * 
+         *
          * @return Command's arguments.
          */
         virtual const char *getArgs() const = 0;
 
         /**
          * @brief Returns current command's arguments count.
-         * 
+         *
          * @param arg          Argument to get.
-         * 
+         *
          * @return Command's arguments count.
          */
         virtual int getArgc() const = 0;
 
         /**
          * @brief Prints message to server's console.
-         * 
+         *
          * @param msg          Message to print to the server's console.
-         * 
+         *
          * @noreturn
          */
         virtual void serverPrint(const char *msg) const = 0;
 
         /**
          * @brief Precaches model.
-         * 
+         *
          * @param model          Model to precache.
-         * 
+         *
          * @return Precached model's index.
          */
         virtual int precacheModel(const char *model) const = 0;
 
         /**
          * @brief Precaches sound.
-         * 
+         *
          * @param sound          Sound to precache.
-         * 
+         *
          * @return Precached sound's index.
          */
         virtual int precacheSound(const char *sound) const = 0;
 
         /**
          * @brief Precaches generic resource.
-         * 
+         *
          * @param generic          Generic resource to precache.
-         * 
+         *
          * @return Precached generic resource's index.
          */
         virtual int precacheGeneric(const char *generic) const = 0;
 
         /**
          * @brief Changes level.
-         * 
+         *
          * @param generic          Level to change to.
-         * 
+         *
          * @noreturn
          */
         virtual void changeLevel(const char *level) const = 0;
 
         /**
          * @brief Executes server's command.
-         * 
+         *
          * @note Executes command in the next frame. To get the result of the command use serverExecute() afterwards.
-         * 
+         *
          * @param cmd          Command to execute.
-         * 
+         *
          * @noreturn
          */
         virtual void serverCommand(const char *cmd) const = 0;
 
         /**
          * @brief Executes previously buffered server's command.
-         * 
+         *
          * @noreturn
          */
         virtual void serverExecute() const = 0;
 
         /**
          * @brief Registers server's command.
-         * 
+         *
          * @param cmd          Command to register.
-         * 
+         *
          * @noreturn
          */
         virtual void registerSrvCommand(const char *cmd) const = 0;
+
+        // TODO: Describe funcs
+        virtual void
+            messageBegin(int msgDest, int msgType, const float *pOrigin = nullptr, IEdict *pEdict = nullptr) const = 0;
+        virtual void messageEnd() const = 0;
+        virtual void writeByte(int byteArg) const = 0;
+        virtual void writeChar(int charArg) const = 0;
+        virtual void writeShort(int shortArg) const = 0;
+        virtual void writeLong(int longArg) const = 0;
+        virtual void writeEntity(int entArg) const = 0;
+        virtual void writeAngle(float angleArg) const = 0;
+        virtual void writeCoord(float coordArg) const = 0;
+        virtual void writeString(const char *strArg) const = 0;
 
     protected:
         virtual ~IEngineFuncs() = default;
     };
 
-    class IEngineFuncsHooked
+    class IEngineFuncsHooked : public ISPModInterface
     {
     public:
+        static constexpr std::uint16_t MAJOR_VERSION = 0;
+        static constexpr std::uint16_t MINOR_VERSION = 0;
+
+        static constexpr std::uint32_t VERSION = (MAJOR_VERSION << 16 | MINOR_VERSION);
+        /**
+         * @brief Gets interface's name.
+         *
+         * @return        Interface's name.
+         */
+        const char *getName() const override
+        {
+            return "IEngineFuncsHooked";
+        }
+
+        /**
+         * @brief Gets interface's version.
+         *
+         * @note The first 16 most significant bits represent major version, the rest represent minor version.
+         *
+         * @return        Interface's version.
+         */
+        std::uint32_t getVersion() const override
+        {
+            return VERSION;
+        }
+
         /**
          * @brief Returns current command's argument.
-         * 
+         *
          * @param arg          Argument to get.
-         * 
+         *
          * @return Command's argument.
          */
         virtual const char *getArg(int arg) const = 0;
 
         /**
          * @brief Returns current command's arguments.
-         * 
+         *
          * @return Command's arguments.
          */
         virtual const char *getArgs() const = 0;
 
         /**
          * @brief Returns current command's arguments count.
-         * 
+         *
          * @param arg          Argument to get.
-         * 
+         *
          * @return Command's arguments count.
          */
         virtual int getArgc() const = 0;
 
         /**
          * @brief Prints message to server's console.
-         * 
+         *
          * @param msg          Message to print to the server console.
-         * 
+         *
          * @noreturn
          */
         virtual void serverPrint(const char *msg) const = 0;
 
         /**
          * @brief Precaches model.
-         * 
+         *
          * @param model          Model to precache.
-         * 
+         *
          * @return Precached model's index.
          */
         virtual int precacheModel(const char *model) const = 0;
 
         /**
          * @brief Precaches sound.
-         * 
+         *
          * @param sound          Sound to precache.
-         * 
+         *
          * @return Precached sound's index.
          */
         virtual int precacheSound(const char *sound) const = 0;
 
         /**
          * @brief Precaches generic resource.
-         * 
+         *
          * @param generic          Generic resource to precache.
-         * 
+         *
          * @return Precached generic resource's index.
          */
         virtual int precacheGeneric(const char *generic) const = 0;
 
         /**
          * @brief Changes level.
-         * 
+         *
          * @param generic          Level to change to.
-         * 
+         *
          * @noreturn
          */
         virtual void changeLevel(const char *level) const = 0;
 
         /**
          * @brief Buffers server's command.
-         * 
+         *
          * @note To get the result of the command use serverExecute() afterwards.
-         * 
+         *
          * @param cmd          Command to execute.
-         * 
+         *
          * @noreturn
          */
         virtual void serverCommand(const char *cmd) const = 0;
 
         /**
          * @brief Executes previously buffered server's command.
-         * 
+         *
          * @noreturn
          */
         virtual void serverExecute() const = 0;
 
         /**
          * @brief Registers server's command.
-         * 
+         *
          * @param cmd          Command to register.
-         * 
+         *
          * @noreturn
          */
         virtual void registerSrvCommand(const char *cmd) const = 0;
+
+        // TODO: Describe funcs
+        virtual void
+            messageBegin(int msgDest, int msgType, const float *pOrigin = nullptr, IEdict *pEdict = nullptr) const = 0;
+        virtual void messageEnd() const = 0;
+        virtual void writeByte(int byteArg) const = 0;
+        virtual void writeChar(int charArg) const = 0;
+        virtual void writeShort(int shortArg) const = 0;
+        virtual void writeLong(int longArg) const = 0;
+        virtual void writeEntity(int entArg) const = 0;
+        virtual void writeAngle(float angleArg) const = 0;
+        virtual void writeCoord(float coordArg) const = 0;
+        virtual void writeString(const char *strArg) const = 0;
 
     protected:
         virtual ~IEngineFuncsHooked() = default;
     };
 
-    class IEngineGlobals
+    class IEngineGlobals : public ISPModInterface
     {
     public:
+        static constexpr std::uint16_t MAJOR_VERSION = 0;
+        static constexpr std::uint16_t MINOR_VERSION = 0;
+
+        static constexpr std::uint32_t VERSION = (MAJOR_VERSION << 16 | MINOR_VERSION);
+        /**
+         * @brief Gets interface's name.
+         *
+         * @return        Interface's name.
+         */
+        const char *getName() const override
+        {
+            return "IEngineGlobals";
+        }
+
+        /**
+         * @brief Gets interface's version.
+         *
+         * @note The first 16 most significant bits represent major version, the rest represent minor version.
+         *
+         * @return        Interface's version.
+         */
+        std::uint32_t getVersion() const override
+        {
+            return VERSION;
+        }
+
         /**
          * @brief Returns current game time.
-         * 
+         *
          * @return Game time.
          */
         virtual float getTime() const = 0;
 
+        virtual const char *getMapName() const = 0;
+
     protected:
         virtual ~IEngineGlobals() = default;
     };
-}
+} // namespace SPMod

--- a/include/public/IForwardSystem.hpp
+++ b/include/public/IForwardSystem.hpp
@@ -304,11 +304,13 @@ namespace SPMod
         /*
          * @brief Deletes forward.
          *
+         * @note Forward will not be deleted if it is being executed.
+         *
          * @param forward   Forward to remove.
          *
-         * @noreturn
+         * @return          True if forward has been successfully deleted, false otherwise.
          */
-        virtual void deleteForward(IForward *forward) = 0;
+        virtual bool deleteForward(IForward *forward) = 0;
 
         /*
          * @brief Adds listener.

--- a/include/public/IMetaFuncs.hpp
+++ b/include/public/IMetaFuncs.hpp
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (C) 2018 SPMod Development Team
+
+ *  This file is part of SPMod.
+
+ *  SPMod is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+
+ *  SPMod is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+
+ *  You should have received a copy of the GNU General Public License
+ *  along with SPMod.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace SPMod
+{
+    class IMetaFuncs
+    {
+    public:
+        /**
+         * @brief Returns ID of message.
+         * 
+         * @param msgName          Message's name.
+         * 
+         * @return ID of the message.
+         */
+        virtual int getUsrMsgId(const char *msgName) const = 0;
+
+        /**
+         * @brief Returns message name.
+         * 
+         * @param msgId         Message's id.
+         * 
+         * @return Name of the message.
+         */
+        virtual const char *getUsrMsgName(int msgId) const = 0;
+
+    protected:
+        virtual ~IMetaFuncs() = default;
+    };
+}

--- a/include/public/IPlayerSystem.hpp
+++ b/include/public/IPlayerSystem.hpp
@@ -21,33 +21,6 @@
 
 #include <cstddef>
 
-#include <archtypes.h>
-
-#if !defined vec_t
-using vec_t = float;
-#endif
-
-#if !defined sqrt
-    #include <cmath>
-#endif
-
-#include <vector.h>
-
-#if !defined vec3_t
-    #define vec3_t Vector
-#endif
-
-#if !defined string_t
-using string_t = unsigned int;
-#endif
-
-#if !defined byte
-using byte = unsigned char;
-#endif
-
-#include <const.h>
-#include <edict.h>
-
 namespace SPMod
 {
     /**
@@ -55,7 +28,10 @@ namespace SPMod
      */
     constexpr unsigned int MAX_PLAYERS = 32U;
 
-    class IPlayer
+    class IEdict;
+    class IMenu;
+
+    class IPlayer : public virtual IEdict
     {
     public:
         /**
@@ -78,20 +54,6 @@ namespace SPMod
          * @return      Player's SteamID.
          */
         virtual const char *getSteamID() const = 0;
-
-        /**
-         * @brief Returns the player's edict_t structure.
-         *
-         * @return      Player's edict_t structure.
-         */
-        virtual edict_t *getEdict() const = 0;
-
-        /**
-         * @brief Returns the player's index.
-         *
-         * @return      Player's index.
-         */
-        virtual unsigned int getIndex() const = 0;
 
         /**
          * @brief Returns the player's userid.
@@ -135,13 +97,43 @@ namespace SPMod
          */
         virtual bool isInGame() const = 0;
 
+        virtual IMenu *getMenu() const = 0;
+        virtual int getMenuPage() const = 0;
+        virtual void closeMenu() = 0;
+
     protected:
         virtual ~IPlayer() = default;
     };
 
-    class IPlayerMngr
+    class IPlayerMngr : public ISPModInterface
     {
     public:
+        static constexpr std::uint16_t MAJOR_VERSION = 0;
+        static constexpr std::uint16_t MINOR_VERSION = 0;
+
+        static constexpr std::uint32_t VERSION = (MAJOR_VERSION << 16 | MINOR_VERSION);
+        /**
+         * @brief Gets interface's name.
+         *
+         * @return        Interface's name.
+         */
+        const char *getName() const override
+        {
+            return "IPlayerMngr";
+        }
+
+        /**
+         * @brief Gets interface's version.
+         *
+         * @note The first 16 most significant bits represent major version, the rest represent minor version.
+         *
+         * @return        Interface's version.
+         */
+        std::uint32_t getVersion() const override
+        {
+            return VERSION;
+        }
+
         /**
          * @brief Returns IPlayer object by its client index.
          *
@@ -160,7 +152,7 @@ namespace SPMod
          *
          * @return          IPlayer object, nullptr if out of range.
          */
-        virtual IPlayer *getPlayer(edict_t *edict) const = 0;
+        virtual IPlayer *getPlayer(IEdict *edict) const = 0;
 
         /**
          * @brief Returns the maximum number of clients.

--- a/include/public/IPluginSystem.hpp
+++ b/include/public/IPluginSystem.hpp
@@ -23,23 +23,13 @@
     #define _vsnprintf vsnprintf
 #endif
 
-#ifdef SP_CLANG
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wunused-parameter"
-#elif defined SP_GCC
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wunused-parameter"
-#elif defined SP_MSVC
+#if defined SP_MSVC
     #pragma warning(push)
     #pragma warning(disable : 4100)
     #pragma warning(disable : 4996)
 #endif
 #include <utlvector.h>
-#if defined SP_CLANG
-    #pragma clang diagnostic pop
-#elif defined SP_GCC
-    #pragma GCC diagnostic pop
-#elif defined SP_MSVC
+#if defined SP_MSVC
     #pragma warning(pop)
 #endif
 

--- a/include/public/ISPGlobal.hpp
+++ b/include/public/ISPGlobal.hpp
@@ -26,6 +26,7 @@
 #include <ICvarSystem.hpp>
 #include <ITimerSystem.hpp>
 #include <IMenuSystem.hpp>
+#include <IEdict.hpp>
 #include <IUtilsSystem.hpp>
 #include <IPlayerSystem.hpp>
 #include <ILoggerSystem.hpp>
@@ -33,6 +34,7 @@
 #include <IPluginSystem.hpp>
 #include <INativeProxy.hpp>
 #include <IEngineFuncs.hpp>
+#include <IMetaFuncs.hpp>
 
 namespace SPMod
 {
@@ -95,6 +97,15 @@ namespace SPMod
          * @return              True if they are allowed to, false otherwise.
          */
         virtual bool canPluginsPrecache() const = 0;
+
+        /**
+         * @brief Gets edict.
+         *
+         * @param index         Edict's index.
+         *
+         * @return              Edict.
+         */
+        virtual IEdict *getEdict(int index) = 0;
 
         /**
          * @brief Finds plugin.
@@ -163,31 +174,38 @@ namespace SPMod
 
         /**
          * @brief Returns SPMod command manager.
-         * 
+         *
          * @return              Command manager.
          */
         virtual ICommandMngr *getCommandManager() const = 0;
 
         /**
          * @brief Returns engine funcs.
-         * 
+         *
          * @return              Engine functions.
          */
         virtual IEngineFuncs *getEngineFuncs() const = 0;
 
         /**
          * @brief Returns engine hooked funcs.
-         * 
+         *
          * @return              Engine hooked functions.
          */
         virtual IEngineFuncsHooked *getEngineHookedFuncs() const = 0;
 
         /**
          * @brief Returns engine globals.
-         * 
+         *
          * @return              Engine globals.
          */
         virtual IEngineGlobals *getEngineGlobals() const = 0;
+
+        /**
+         * @brief Returns engine globals.
+         *
+         * @return              Engine globals.
+         */
+        virtual IMetaFuncs *getMetaFuncs() const = 0;
 
         /**
          * @brief Registers module's interface.

--- a/include/public/ITimerSystem.hpp
+++ b/include/public/ITimerSystem.hpp
@@ -56,6 +56,13 @@ namespace SPMod
          */
         virtual void setPause(bool pause) = 0;
 
+        /**
+         * @brief Gets timer's data.
+         *
+         * @return        Timer's data.
+         */
+        virtual void *getData() const = 0;
+
     protected:
         virtual ~ITimer() = default;
     };
@@ -102,12 +109,17 @@ namespace SPMod
          *
          * @param interval    Time interval.
          * @param func        Callback function.
-         * @param data        Data that is passed to timer callback.
+         * @param cbData      Data that is passed to timer callback.
+         * @param data        Data that is passed to the plugin.
          * @param pause       True if timer should be paused after creation, false otherwise.
          *
          * @return            Created timer.
          */
-        virtual ITimer *createTimer(float interval, TimerCallback func, void *data = nullptr, bool pause = false) = 0;
+        virtual ITimer *createTimer(float interval,
+                                    TimerCallback func,
+                                    void *cbData = nullptr,
+                                    void *data = nullptr,
+                                    bool pause = false) = 0;
 
         /**
          * @brief Removes a timer.

--- a/src/CmdSystem.cpp
+++ b/src/CmdSystem.cpp
@@ -19,7 +19,7 @@
 
 #include "spmod.hpp"
 
-Command::Command(std::string_view cmd, std::string_view info, ICommand::Callback *cb, void *data)
+Command::Command(std::string_view cmd, std::string_view info, ICommand::Callback cb, void *data)
     : m_cmd(cmd), m_info(info), m_callback(cb), m_data(data)
 {
 }
@@ -34,12 +34,12 @@ const char *Command::getInfo() const
     return getInfoCore().data();
 }
 
-ICommand::Callback *Command::getCallback() const
+ICommand::Callback Command::getCallback() const
 {
     return m_callback;
 }
 
-void *Command::getData() const
+void *Command::getCallbackData() const
 {
     return m_data;
 }
@@ -57,7 +57,7 @@ std::string_view Command::getInfoCore() const
 ClientCommand::ClientCommand(std::string_view cmd,
                              std::string_view info,
                              std::uint32_t flags,
-                             ICommand::Callback *cb,
+                             ICommand::Callback cb,
                              void *data)
     : Command(cmd, info, cb, data), m_flags(flags)
 {
@@ -79,7 +79,7 @@ uint32_t ClientCommand::getAccess() const
     return m_flags;
 }
 
-ServerCommand::ServerCommand(std::string_view cmd, std::string_view info, ICommand::Callback *cb, void *data)
+ServerCommand::ServerCommand(std::string_view cmd, std::string_view info, ICommand::Callback cb, void *data)
     : Command(cmd, info, cb, data)
 {
 }
@@ -103,7 +103,7 @@ ICommand *CommandMngr::registerCommand(ICommand::Type type,
                                        const char *cmd,
                                        const char *info,
                                        std::uint32_t flags,
-                                       ICommand::Callback *cb,
+                                       ICommand::Callback cb,
                                        void *data)
 {
     switch (type)

--- a/src/CmdSystem.hpp
+++ b/src/CmdSystem.hpp
@@ -125,6 +125,8 @@ public:
     std::size_t getCommandsNum(ICommand::Type type);
     void clearCommands();
 
+    META_RES ClientCommandMeta(std::shared_ptr<Edict> entity, std::string&& cmd);
+
 private:
     std::vector<std::shared_ptr<Command>> m_clientCommands;
     std::vector<std::shared_ptr<Command>> m_serverCommands;

--- a/src/CmdSystem.hpp
+++ b/src/CmdSystem.hpp
@@ -31,15 +31,15 @@ class Command : public ICommand
 public:
     Command() = delete;
     ~Command() = default;
-    Command(std::string_view cmd, std::string_view info, ICommand::Callback *cb, void *data);
+    Command(std::string_view cmd, std::string_view info, ICommand::Callback cb, void *data);
 
     const char *getCmd() const override;
     const char *getInfo() const override;
-    void *getData() const override;
 
     std::string_view getCmdCore() const;
     std::string_view getInfoCore() const;
-    ICommand::Callback *getCallback() const;
+    ICommand::Callback getCallback() const;
+    void *getCallbackData() const;
 
     virtual bool hasAccessCore(std::shared_ptr<Player> player) const = 0;
 
@@ -51,9 +51,9 @@ protected:
     std::string m_info;
 
     /* cmd callback */
-    ICommand::Callback *m_callback;
+    ICommand::Callback m_callback;
 
-    /* command data */
+    /* callback data */
     void *m_data;
 };
 
@@ -66,7 +66,7 @@ public:
     ClientCommand(ClientCommand &&other) = default;
     ~ClientCommand() = default;
 
-    ClientCommand(std::string_view cmd, std::string_view info, std::uint32_t flags, ICommand::Callback *cb, void *data);
+    ClientCommand(std::string_view cmd, std::string_view info, std::uint32_t flags, ICommand::Callback cb, void *data);
 
     bool hasAccess(IPlayer *player) const override;
     bool hasAccessCore(std::shared_ptr<Player> player) const override;
@@ -86,7 +86,7 @@ public:
     ServerCommand(ServerCommand &&other) = default;
     ~ServerCommand() = default;
 
-    ServerCommand(std::string_view cmd, std::string_view info, ICommand::Callback *cb, void *data);
+    ServerCommand(std::string_view cmd, std::string_view info, ICommand::Callback cb, void *data);
 
     bool hasAccess(IPlayer *player) const override;
     bool hasAccessCore(std::shared_ptr<Player> player) const override;
@@ -103,7 +103,7 @@ public:
                               const char *cmd,
                               const char *info,
                               std::uint32_t flags,
-                              ICommand::Callback *cb,
+                              ICommand::Callback cb,
                               void *data) override;
 
     template<typename T, typename... Args, typename = std::enable_if_t<std::is_base_of_v<Command, T>>>

--- a/src/CvarSystem.cpp
+++ b/src/CvarSystem.cpp
@@ -147,7 +147,7 @@ int Cvar::asInt() const
 {
     try
     {
-        return std::stoi(m_value, nullptr, 0);
+        return std::stoi(m_value);
     }
     catch (const std::exception &e [[maybe_unused]])
     {

--- a/src/Edict.cpp
+++ b/src/Edict.cpp
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (C) 2018-2019 SPMod Development Team
+ *
+ *  This file is part of SPMod.
+ *
+ *  SPMod is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  SPMod is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with SPMod.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "spmod.hpp"
+
+Edict::Edict(edict_t *edict) : m_edict(edict)
+{
+}
+
+Edict::Edict(int index) : m_edict(INDEXENT(index))
+{
+}
+
+int Edict::getIndex() const
+{
+    return ENTINDEX(m_edict);
+}
+
+const char *Edict::getClassName() const
+{
+    return STRING(m_edict->v.classname);
+}
+
+void Edict::getOrigin(float *origin) const
+{
+    const vec3_t &edPos = m_edict->v.origin;
+    edPos.CopyToArray(origin);
+}
+
+void Edict::getVelocity(float *velocity) const
+{
+    const vec3_t &edVelocity = m_edict->v.velocity;
+    edVelocity.CopyToArray(velocity);
+}
+
+void Edict::setVelocity(const float *velocity)
+{
+    m_edict->v.velocity = const_cast<float *>(velocity);
+}
+
+float Edict::getHealth() const
+{
+    return m_edict->v.health;
+}
+
+void Edict::setHealth(float health)
+{
+    m_edict->v.health = health;
+}
+
+void *Edict::getPrivateData() const
+{
+    return m_edict->pvPrivateData;
+}
+
+edict_t *Edict::getInternalEdict() const
+{
+    return m_edict;
+}

--- a/src/Edict.hpp
+++ b/src/Edict.hpp
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (C) 2018-2019 SPMod Development Team
+ *
+ *  This file is part of SPMod.
+ *
+ *  SPMod is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  SPMod is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with SPMod.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "spmod.hpp"
+
+class Edict : public virtual IEdict
+{
+public:
+    Edict() = delete;
+    Edict(edict_t *edict);
+    Edict(int index);
+    ~Edict() = default;
+
+    // IEdict
+    int getIndex() const override;
+    const char *getClassName() const override;
+    void getOrigin(float *origin) const override;
+    void getVelocity(float *velocity) const override;
+    void setVelocity(const float *velocity) override;
+    float getHealth() const override;
+    void setHealth(float health) override;
+    void *getPrivateData() const override;
+
+    // Edict
+    edict_t *getInternalEdict() const;
+
+protected:
+    edict_t *m_edict;
+};

--- a/src/EngineFuncs.cpp
+++ b/src/EngineFuncs.cpp
@@ -74,6 +74,56 @@ void EngineFuncs::registerSrvCommand(const char *cmd) const
     REG_SVR_COMMAND(cmd, PluginSrvCmd);
 }
 
+void EngineFuncs::messageBegin(int msgDest, int msgType, const float *pOrigin, IEdict *pEdict) const
+{
+    MESSAGE_BEGIN(msgDest, msgType, pOrigin, INDEXENT(pEdict->getIndex()));
+}
+
+void EngineFuncs::messageEnd() const
+{
+    MESSAGE_END();
+}
+
+void EngineFuncs::writeByte(int byteArg) const
+{
+    WRITE_BYTE(byteArg);
+}
+
+void EngineFuncs::writeChar(int charArg) const
+{
+    WRITE_CHAR(charArg);
+}
+
+void EngineFuncs::writeShort(int shortArg) const
+{
+    WRITE_SHORT(shortArg);
+}
+
+void EngineFuncs::writeLong(int longArg) const
+{
+    WRITE_LONG(longArg);
+}
+
+void EngineFuncs::writeEntity(int entArg) const
+{
+    WRITE_ENTITY(entArg);
+}
+
+void EngineFuncs::writeAngle(float angleArg) const
+{
+    WRITE_ANGLE(angleArg);
+}
+
+void EngineFuncs::writeCoord(float coordArg) const
+{
+    WRITE_COORD(coordArg);
+}
+
+void EngineFuncs::writeString(const char *strArg) const
+{
+    WRITE_STRING(strArg);
+}
+
 const char *EngineFuncsHooked::getArg(int arg) const
 {
     return gpEngineFuncs->pfnCmd_Argv(arg);
@@ -129,7 +179,62 @@ void EngineFuncsHooked::registerSrvCommand(const char *cmd) const
     gpEngineFuncs->pfnAddServerCommand(cmd, PluginSrvCmd);
 }
 
+void EngineFuncsHooked::messageBegin(int msgDest, int msgType, const float *pOrigin, IEdict *pEdict) const
+{
+    gpEngineFuncs->pfnMessageBegin(msgDest, msgType, pOrigin, INDEXENT(pEdict->getIndex()));
+}
+
+void EngineFuncsHooked::messageEnd() const
+{
+    gpEngineFuncs->pfnMessageEnd();
+}
+
+void EngineFuncsHooked::writeByte(int byteArg) const
+{
+    gpEngineFuncs->pfnWriteByte(byteArg);
+}
+
+void EngineFuncsHooked::writeChar(int charArg) const
+{
+    gpEngineFuncs->pfnWriteChar(charArg);
+}
+
+void EngineFuncsHooked::writeShort(int shortArg) const
+{
+    gpEngineFuncs->pfnWriteShort(shortArg);
+}
+
+void EngineFuncsHooked::writeLong(int longArg) const
+{
+    gpEngineFuncs->pfnWriteLong(longArg);
+}
+
+void EngineFuncsHooked::writeEntity(int entArg) const
+{
+    gpEngineFuncs->pfnWriteEntity(entArg);
+}
+
+void EngineFuncsHooked::writeAngle(float angleArg) const
+{
+    gpEngineFuncs->pfnWriteAngle(angleArg);
+}
+
+void EngineFuncsHooked::writeCoord(float coordArg) const
+{
+    gpEngineFuncs->pfnWriteCoord(coordArg);
+}
+
+void EngineFuncsHooked::writeString(const char *strArg) const
+{
+    gpEngineFuncs->pfnWriteString(strArg);
+}
+
 float EngineGlobals::getTime() const
 {
     return gpGlobals->time;
+}
+
+const char *EngineGlobals::getMapName() const
+{
+    return STRING(gpGlobals->mapname);
 }

--- a/src/EngineFuncs.hpp
+++ b/src/EngineFuncs.hpp
@@ -39,6 +39,16 @@ public:
     void serverCommand(const char* cmd) const override;
     void serverExecute() const override;
     void registerSrvCommand(const char *cmd) const override;
+    void messageBegin(int msgDest, int msgType, const float *pOrigin, IEdict *pEdict) const override;
+    void messageEnd() const override;
+    void writeByte(int byteArg) const override;
+    void writeChar(int charArg) const override;
+    void writeShort(int shortArg) const override;
+    void writeLong(int longArg) const override;
+    void writeEntity(int entArg) const override;
+    void writeAngle(float angleArg) const override;
+    void writeCoord(float coordArg) const override;
+    void writeString(const char *strArg) const override;
 };
 
 class EngineFuncsHooked : public IEngineFuncsHooked
@@ -59,6 +69,16 @@ public:
     void serverCommand(const char* cmd) const override;
     void serverExecute() const override;
     void registerSrvCommand(const char *cmd) const override;
+    void messageBegin(int msgDest, int msgType, const float *pOrigin, IEdict *pEdict) const override;
+    void messageEnd() const override;
+    void writeByte(int byteArg) const override;
+    void writeChar(int charArg) const override;
+    void writeShort(int shortArg) const override;
+    void writeLong(int longArg) const override;
+    void writeEntity(int entArg) const override;
+    void writeAngle(float angleArg) const override;
+    void writeCoord(float coordArg) const override;
+    void writeString(const char *strArg) const override;
 };
 
 class EngineGlobals : public IEngineGlobals
@@ -67,6 +87,6 @@ public:
     EngineGlobals() = default;
     ~EngineGlobals() = default;
     
-
     float getTime() const override;
+    const char *getMapName() const override;
 };

--- a/src/ForwardSystem.cpp
+++ b/src/ForwardSystem.cpp
@@ -448,9 +448,10 @@ std::shared_ptr<Forward>
     return forward;
 }
 
-void ForwardMngr::deleteForward(IForward *forward)
+bool ForwardMngr::deleteForward(IForward *forward)
 {
-    m_forwards.erase(forward->getName());
+    auto iter = m_forwards.find(forward->getName());
+    return deleteForwardCore(iter);
 }
 
 void ForwardMngr::addForwardListener(ForwardCallback func)
@@ -461,11 +462,27 @@ void ForwardMngr::addForwardListener(ForwardCallback func)
 void ForwardMngr::clearForwards()
 {
     m_forwards.clear();
+    m_callbacks.clear();
 }
 
-void ForwardMngr::deleteForwardCore(std::shared_ptr<Forward> fwd)
+bool ForwardMngr::deleteForwardCore(std::shared_ptr<Forward> fwd)
 {
-    m_forwards.erase(fwd->getNameCore().data());
+    if (!fwd->isExecuted())
+    {
+        m_forwards.erase(fwd->getNameCore().data());
+        return true;
+    }
+    return false;
+}
+
+bool ForwardMngr::deleteForwardCore(const std::unordered_multimap<std::string, std::shared_ptr<Forward>>::iterator &iter)
+{
+    if (!iter->second->isExecuted())
+    {
+        m_forwards.erase(iter);
+        return true;
+    }
+    return false;
 }
 
 std::shared_ptr<Forward> ForwardMngr::getDefaultForward(ForwardMngr::FwdDefault fwd) const

--- a/src/ForwardSystem.hpp
+++ b/src/ForwardSystem.hpp
@@ -57,9 +57,9 @@ public:
     bool pushString(const char *string) override;
     bool pushString(char *buffer, std::size_t length, IForward::StringFlags sflags, bool copyback) override;
 
-    bool isExecuted() const;
-
     void resetParams() override;
+
+    bool isExecuted() const;
 
 protected:
     /* forward name */
@@ -184,12 +184,13 @@ public:
     IForward *
         createForward(const char *name, IPlugin *plugin, std::size_t paramsnum, IForward::Param::Type *params) override;
 
-    void deleteForward(IForward *forward) override;
+    bool deleteForward(IForward *forward) override;
     void addForwardListener(ForwardCallback func) override;
 
     // ForwardMngr
     void clearForwards();
-    void deleteForwardCore(std::shared_ptr<Forward> fwd);
+    bool deleteForwardCore(std::shared_ptr<Forward> fwd);
+    bool deleteForwardCore(const std::unordered_multimap<std::string, std::shared_ptr<Forward>>::iterator &iter);
     std::shared_ptr<Forward> getDefaultForward(ForwardMngr::FwdDefault fwd) const;
 
     void addDefaultsForwards();

--- a/src/MetaFuncs.cpp
+++ b/src/MetaFuncs.cpp
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (C) 2018 SPMod Development Team
+
+ *  This file is part of SPMod.
+
+ *  SPMod is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+
+ *  SPMod is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+
+ *  You should have received a copy of the GNU General Public License
+ *  along with SPMod.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "spmod.hpp"
+
+int MetaFuncs::getUsrMsgId(const char *msgName) const
+{
+    return GET_USER_MSG_ID(PLID, msgName, nullptr);
+}
+
+const char *MetaFuncs::getUsrMsgName(int msgId) const
+{
+    return GET_USER_MSG_NAME(PLID, msgId, nullptr);
+}

--- a/src/MetaFuncs.hpp
+++ b/src/MetaFuncs.hpp
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2018 SPMod Development Team
+
+ *  This file is part of SPMod.
+
+ *  SPMod is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+
+ *  SPMod is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+
+ *  You should have received a copy of the GNU General Public License
+ *  along with SPMod.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "spmod.hpp"
+
+class MetaFuncs : public IMetaFuncs
+{
+public:
+    MetaFuncs() = default;
+    ~MetaFuncs() = default;
+
+    int getUsrMsgId(const char *msgName) const override;
+    const char *getUsrMsgName(int msgId) const override;
+};

--- a/src/NativeProxy.hpp
+++ b/src/NativeProxy.hpp
@@ -47,7 +47,7 @@ private:
 class NativeProxy final : public INativeProxy
 {
 public:
-    NativeProxy() = delete;
+    NativeProxy() = default;
     NativeProxy(const NativeProxy &other) = delete;
     NativeProxy(NativeProxy &&other) = default;
     ~NativeProxy() = default;

--- a/src/PlayerSystem.hpp
+++ b/src/PlayerSystem.hpp
@@ -23,6 +23,10 @@
 
 class Menu;
 
+#if defined SP_MSVC
+    #pragma warning(push)
+    #pragma warning(disable : 4250) // inheritance via dominance warning
+#endif
 class Player : public Edict, public IPlayer
 {
 public:
@@ -74,6 +78,9 @@ private:
     std::weak_ptr<Menu> m_menu;
     int m_menuPage;
 };
+#if defined SP_MSVC
+    #pragma warning(pop)
+#endif
 
 class PlayerMngr : public IPlayerMngr
 {

--- a/src/PlayerSystem.hpp
+++ b/src/PlayerSystem.hpp
@@ -23,25 +23,26 @@
 
 class Menu;
 
-class Player : public IPlayer
+class Player : public Edict, public IPlayer
 {
 public:
     Player() = delete;
     ~Player() = default;
-    Player(edict_t *edict, unsigned int index);
+    Player(std::shared_ptr<Edict> edict);
 
     // IPlayer
     const char *getName() const override;
     const char *getIPAddress() const override;
     const char *getSteamID() const override;
-    edict_t *getEdict() const override;
-    unsigned int getIndex() const override;
     int getUserId() const override;
     bool isAlive() const override;
     bool isConnected() const override;
     bool isFake() const override;
     bool isHLTV() const override;
     bool isInGame() const override;
+    void closeMenu() override;
+    IMenu *getMenu() const override;
+    int getMenuPage() const override;
 
     // Player
     std::string_view getNameCore() const;
@@ -49,9 +50,8 @@ public:
     std::string_view getSteamIDCore() const;
     void setName(std::string_view newname);
 
-    std::weak_ptr<Menu> getMenu() const;
+    std::weak_ptr<Menu> getMenuCore() const;
     void setMenu(std::shared_ptr<Menu> menu);
-    int getMenuPage() const;
     void setMenuPage(int page);
 
     void connect(std::string_view name, std::string_view ip);
@@ -60,9 +60,10 @@ public:
     void putInServer();
     void authorize(std::string_view authid);
 
+    void setOwnInstance(std::shared_ptr<Player> instance);
+
 private:
-    edict_t *m_edict;
-    unsigned int m_index;
+    std::weak_ptr<Player> m_ownInstance;
     bool m_connected;
     bool m_inGame;
     int m_userID;
@@ -82,13 +83,15 @@ public:
 
     // IPlayerManager
     IPlayer *getPlayer(int index) const override;
-    IPlayer *getPlayer(edict_t *edict) const override;
+    IPlayer *getPlayer(IEdict *edict) const override;
     unsigned int getMaxClients() const override;
     unsigned int getNumPlayers() const override;
 
     // PlayerManager
     std::shared_ptr<Player> getPlayerCore(int index) const;
+    std::shared_ptr<Player> getPlayerCore(std::shared_ptr<Edict> edict) const;
     std::shared_ptr<Player> getPlayerCore(edict_t *edict) const;
+    std::shared_ptr<Player> getPlayerCore(IPlayer *player) const;
 
     bool ClientConnect(edict_t *pEntity, const char *pszName, const char *pszAddress, char szRejectReason[128]);
 

--- a/src/RehldsApi.cpp
+++ b/src/RehldsApi.cpp
@@ -38,6 +38,8 @@ static void SV_DropClientHook(IRehldsHook_SV_DropClient *chain, IGameClient *cli
     forward->pushString(string);
     forward->execFunc(nullptr);
 
+    plr->closeMenu();
+
     chain->callNext(client, crash, string);
 
     PlayerMngr::m_playersNum--;

--- a/src/SPGlobal.hpp
+++ b/src/SPGlobal.hpp
@@ -52,6 +52,8 @@ public:
     IEngineFuncs *getEngineFuncs() const override;
     IEngineFuncsHooked *getEngineHookedFuncs() const override;
     IEngineGlobals *getEngineGlobals() const override;
+    IMetaFuncs *getMetaFuncs() const override;
+    IEdict *getEdict(int index) override;
     IUtils *getUtils() const override;
 
     bool registerInterface(IInterface *interface) override;
@@ -70,6 +72,8 @@ public:
     const std::unique_ptr<LoggerMngr> &getLoggerManagerCore() const;
     const std::unique_ptr<PlayerMngr> &getPlayerManagerCore() const;
     const std::unique_ptr<NativeProxy> &getNativeProxyCore() const;
+    std::shared_ptr<Edict> getEdictCore(int index);
+    void clearEdicts();
     const auto &getInterfacesList() const
     {
         return m_interfaces;
@@ -100,15 +104,17 @@ private:
     std::unique_ptr<MenuMngr> m_menuManager;
     std::unique_ptr<PlayerMngr> m_plrManager;
     std::unique_ptr<NativeProxy> m_nativeProxy;
-    std::unique_ptr<Utils> m_utils;
     std::unique_ptr<EngineFuncs> m_engineFuncs;
     std::unique_ptr<EngineFuncsHooked> m_engineFuncsHooked;
     std::unique_ptr<EngineGlobals> m_engineGlobals;
+    std::unique_ptr<MetaFuncs> m_metaFuncs;
+    std::unique_ptr<Utils> m_utils;
 
     std::string m_modName;
     std::unordered_map<std::string, IInterface *> m_interfaces;
     std::vector<std::unique_ptr<Extension>> m_extHandles;
     std::vector<IPluginMngr *> m_pluginManagers;
+    std::unordered_map<int, std::shared_ptr<Edict>> m_edicts;
 
     bool m_canPluginsPrecache;
 };

--- a/src/SrvCommand.cpp
+++ b/src/SrvCommand.cpp
@@ -116,8 +116,8 @@ void PluginSrvCmd()
     {
         if (!cmd->getCmdCore().compare(argv))
         {
-            ICommand::Callback *func = cmd->getCallback();
-            (*func)(nullptr, cmd.get());
+            ICommand::Callback func = cmd->getCallback();
+            func(nullptr, cmd.get(), cmd->getCallbackData());
         }
     }
 }

--- a/src/TimerSystem.cpp
+++ b/src/TimerSystem.cpp
@@ -19,8 +19,9 @@
 
 #include "spmod.hpp"
 
-Timer::Timer(float interval, TimerCallback func, void *data, bool pause)
-    : m_interval(interval), m_callback(func), m_data(data), m_paused(pause), m_lastExec(gpGlobals->time)
+Timer::Timer(float interval, TimerCallback func, void *cbData, void *data, bool pause)
+    : m_interval(interval), m_callback(func), m_cbData(cbData), m_data(data), m_paused(pause),
+      m_lastExec(gpGlobals->time)
 {
     if (m_interval <= 0.0f)
         throw std::runtime_error("Interval lesser or equal to 0");
@@ -54,14 +55,19 @@ bool Timer::exec(float gltime)
 {
     m_lastExec = gltime;
 
-    return m_callback(this, m_data);
+    return m_callback(this, m_cbData);
 }
 
-ITimer *TimerMngr::createTimer(float interval, TimerCallback func, void *data, bool pause)
+void *Timer::getData() const
+{
+    return m_data;
+}
+
+ITimer *TimerMngr::createTimer(float interval, TimerCallback func, void *cbData, void *data, bool pause)
 {
     try
     {
-        return createTimerCore(interval, func, data, pause).get();
+        return createTimerCore(interval, func, cbData, data, pause).get();
     }
     catch (const std::runtime_error &e [[maybe_unused]])
     {

--- a/src/TimerSystem.hpp
+++ b/src/TimerSystem.hpp
@@ -35,7 +35,7 @@ public:
         return m_timers.emplace_back(std::make_shared<Timer>(std::forward<Args>(args)...));
     }
 
-    ITimer *createTimer(float interval, TimerCallback func, void *data, bool pause) override;
+    ITimer *createTimer(float interval, TimerCallback callback, void *cbData, void *data, bool pause) override;
 
     void removeTimer(ITimer *timer) override;
     void execTimer(ITimer *timer) override;
@@ -63,12 +63,13 @@ public:
     Timer(Timer &&other) = default;
     ~Timer() = default;
 
-    Timer(float interval, TimerCallback func, void *data, bool pause);
+    Timer(float interval, TimerCallback func, void *cbData, void *data, bool pause);
 
     float getInterval() const override;
     bool isPaused() const override;
     void setInterval(float newint) override;
     void setPause(bool pause) override;
+    void *getData() const override;
 
 private:
     bool exec(float time);
@@ -80,6 +81,9 @@ private:
     TimerCallback m_callback;
 
     /* callback data */
+    void *m_cbData;
+
+    /* plugin data */
     void *m_data;
 
     /* Pause state */

--- a/src/UtilsSystem.hpp
+++ b/src/UtilsSystem.hpp
@@ -37,4 +37,6 @@ public:
     std::size_t strCopyCore(char *buffer, std::size_t size, std::string_view src) const;
 
     std::string strReplacedCore(std::string_view source, std::string_view from, std::string_view to) const;
+
+    void ShowMenu(std::shared_ptr<Edict> pEdict, int slots, int time, const char *menu, std::size_t menuLength);
 };

--- a/src/dllapi.cpp
+++ b/src/dllapi.cpp
@@ -32,7 +32,7 @@ static qboolean ClientConnect(edict_t *pEntity, const char *pszName, const char 
 static void ClientCommand(edict_t *pEntity)
 {
     using def = ForwardMngr::FwdDefault;
-
+    std::shared_ptr<Edict> spEdict = gSPGlobal->getEdictCore(ENTINDEX(pEntity));
     {
         int result;
         std::shared_ptr<Forward> fwdCmd = gSPGlobal->getForwardManagerCore()->getDefaultForward(def::ClientCommmand);
@@ -50,12 +50,18 @@ static void ClientCommand(edict_t *pEntity)
     META_RES res = MRES_IGNORED;
 
     std::string strCmd(CMD_ARGV(0));
+    
+    if (strCmd == "menuselect")
+    {
+        res = gSPGlobal->getMenuManagerCore()->ClientCommand(pEntity);
+        RETURN_META(res);
+    }
 
     const std::unique_ptr<CommandMngr> &cmdMngr = gSPGlobal->getCommandManagerCore();
-    std::shared_ptr<Player> player = gSPGlobal->getPlayerManagerCore()->getPlayerCore(pEntity);
+    std::shared_ptr<Player> player = gSPGlobal->getPlayerManagerCore()->getPlayerCore(spEdict);
     if (cmdMngr->getCommandsNum(ICommand::Type::Client))
     {
-        if (!strCmd.compare("say") || !strCmd.compare("say_team"))
+        if (strCmd == "say" || strCmd == "say_team")
         {
             strCmd += ' ';
             strCmd += CMD_ARGV(1);
@@ -67,8 +73,8 @@ static void ClientCommand(edict_t *pEntity)
             if (std::regex_search(strCmd, cmdToMatch) && cmd->hasAccessCore(player))
             {
                 IForward::ReturnValue result = IForward::ReturnValue::Ignored;
-                ICommand::Callback *func = cmd->getCallback();
-                result = (*func)(player.get(), cmd.get());
+                ICommand::Callback func = cmd->getCallback();
+                result = func(player.get(), cmd.get(), cmd->getCallbackData());
 
                 if (result == IForward::ReturnValue::Stop || result == IForward::ReturnValue::Handled)
                 {
@@ -78,11 +84,6 @@ static void ClientCommand(edict_t *pEntity)
                 }
             }
         }
-    }
-
-    if (!strCmd.compare("menuselect"))
-    {
-        res = gSPGlobal->getMenuManagerCore()->ClientCommand(pEntity);
     }
 
     RETURN_META(res);
@@ -150,6 +151,7 @@ static void ServerActivatePost(edict_t *pEdictList, int edictCount [[maybe_unuse
 {
     using DefFwd = ForwardMngr::FwdDefault;
 
+    gSPGlobal->clearEdicts();
     gSPGlobal->getPlayerManagerCore()->ServerActivatePost(pEdictList, clientMax);
 
     const std::unique_ptr<ForwardMngr> &fwdMngr = gSPGlobal->getForwardManagerCore();

--- a/src/dllapi.cpp
+++ b/src/dllapi.cpp
@@ -58,35 +58,7 @@ static void ClientCommand(edict_t *pEntity)
     }
 
     const std::unique_ptr<CommandMngr> &cmdMngr = gSPGlobal->getCommandManagerCore();
-    std::shared_ptr<Player> player = gSPGlobal->getPlayerManagerCore()->getPlayerCore(spEdict);
-    if (cmdMngr->getCommandsNum(ICommand::Type::Client))
-    {
-        if (strCmd == "say" || strCmd == "say_team")
-        {
-            strCmd += ' ';
-            strCmd += CMD_ARGV(1);
-        }
-
-        for (const auto &cmd : cmdMngr->getCommandList(ICommand::Type::Client))
-        {
-            std::regex cmdToMatch(cmd->getCmdCore().data());
-            if (std::regex_search(strCmd, cmdToMatch) && cmd->hasAccessCore(player))
-            {
-                IForward::ReturnValue result = IForward::ReturnValue::Ignored;
-                ICommand::Callback func = cmd->getCallback();
-                result = func(player.get(), cmd.get(), cmd->getCallbackData());
-
-                if (result == IForward::ReturnValue::Stop || result == IForward::ReturnValue::Handled)
-                {
-                    res = MRES_SUPERCEDE;
-                    if (result == IForward::ReturnValue::Stop)
-                        break;
-                }
-            }
-        }
-    }
-
-    RETURN_META(res);
+    RETURN_META(cmdMngr->ClientCommandMeta(spEdict, std::move(strCmd)));
 }
 
 void ClientPutInServer(edict_t *pEntity)

--- a/src/engine_api.cpp
+++ b/src/engine_api.cpp
@@ -39,10 +39,10 @@ static void ChangeLevel(const char *s1, const char *s2 [[maybe_unused]])
 static void
     MessageBegin_Pre(int msg_dest [[maybe_unused]], int msg_type, const float *pOrigin [[maybe_unused]], edict_t *ed)
 {
+    std::shared_ptr<Player> spPlayer = gSPGlobal->getPlayerManagerCore()->getPlayerCore(ENTINDEX(ed));
     if (msg_type == gmsgShowMenu || msg_type == gmsgVGUIMenu)
     {
-        std::shared_ptr<Player> pPlayer = gSPGlobal->getPlayerManagerCore()->getPlayerCore(ed);
-        gSPGlobal->getMenuManagerCore()->closeMenu(pPlayer);
+        spPlayer->closeMenu();
     }
     RETURN_META(MRES_IGNORED);
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,3 @@
-add_project_arguments('-DSPMOD_CORE', language : [ 'c', 'cpp' ])
-
 if build_machine.system() == 'linux'
     add_project_link_arguments('-ldl', language : [ 'c', 'cpp'])
 elif build_machine.system() == 'windows'
@@ -29,6 +27,8 @@ sourceFiles = files('h_export.cpp',
                     'ValveInterface.cpp',
                     'UtilsSystem.cpp',
                     'NativeProxy.cpp',
-                    'EngineFuncs.cpp')
+                    'EngineFuncs.cpp',
+                    'MetaFuncs.cpp',
+                    'Edict.cpp')
 
 shared_library('spmod_mm', sourceFiles, include_directories : includeDirs, gnu_symbol_visibility : 'hidden')

--- a/src/meta_api.cpp
+++ b/src/meta_api.cpp
@@ -100,9 +100,7 @@ C_DLLEXPORT int Meta_Detach(PLUG_LOADTIME now [[maybe_unused]], PL_UNLOAD_REASON
     fwdMngr->getDefaultForward(def::PluginEnd)->execFunc(nullptr);
     fwdMngr->clearForwards();
 
-    /*const std::unique_ptr<PluginMngr> &plMngr = gSPGlobal->getPluginManagerCore();
-    plMngr->clearPlugins();
-    plMngr->clearNatives();*/
+    gSPGlobal->unloadExts();
 
     gSPGlobal->getTimerManagerCore()->clearTimers();
     gSPGlobal->getCommandManagerCore()->clearCommands();

--- a/src/spmod.hpp
+++ b/src/spmod.hpp
@@ -38,24 +38,9 @@
 #endif
 
 // ReHLDS
-#ifdef SP_CLANG
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wnon-virtual-dtor"
-#elif defined SP_GCC
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
-    #pragma GCC diagnostic ignored "-Wpedantic"
-#endif
-
 #include <osconfig.h>
 #include <usercmd.h>
 #include <rehlds_api.h>
-
-#ifdef SP_CLANG
-    #pragma clang diagnostic pop
-#elif defined SP_GCC
-    #pragma GCC diagnostic pop
-#endif
 
 #undef max
 #undef min
@@ -113,6 +98,7 @@ using namespace SPMod;
 
 // SPMod specific
 #include <SPConfig.hpp>
+#include "Edict.hpp"
 #include "UtilsSystem.hpp"
 #include "LoggingSystem.hpp"
 #include "ForwardSystem.hpp"
@@ -124,6 +110,7 @@ using namespace SPMod;
 #include "ExtensionSystem.hpp"
 #include "NativeProxy.hpp"
 #include "EngineFuncs.hpp"
+#include "MetaFuncs.hpp"
 #include "SPGlobal.hpp"
 
 constexpr auto gSPModAuthor = "SPMod Development Team";


### PR DESCRIPTION
This PR introduce several improvements to the api.

## Description
- `IEdict` class for accessing `edict_t` struct properties
- `IMetaFuncs` class for accessing metamod functions
- Added missing `ISPModInterface` for several interfaces
- Exported message engine functions
- `UTIL_ShowMenu` has been moved to utils
- Fixed menu code broken by #52 
- Allow to pass custom data to listeners callbacks
- Removed unneeded pragmas for gcc & clang
- `deleteForward` now returns bool to indicate if removing has been successful (removing is not allowed when forward is being executed)
- Added `setOwnInstance` functions to some classes to easier access their `shared_ptr` inside class method without involving their managers

## Motivation and Context
These changes are required to make sourcepawn adapter work. 

## How has this been tested?
The changes were tested using sourcepawn adapter which is present on `adopt-sourcepawn` branch.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
